### PR TITLE
Remove Changed When from Keycloak Client

### DIFF
--- a/tasks/create-client.yml
+++ b/tasks/create-client.yml
@@ -6,6 +6,14 @@
     auth_username: "{{ keycloak_auth_username }}"
     auth_password: "{{ keycloak_auth_password }}"
     client_id: "{{ keycloak_client_id }}"
+    state: present
+- name: Set the Protocol Mappers for the client
+  keycloak_client:
+    auth_keycloak_url: "{{ keycloak_base_url }}"
+    auth_realm: "{{ keycloak_auth_realm }}"
+    auth_username: "{{ keycloak_auth_username }}"
+    auth_password: "{{ keycloak_auth_password }}"
+    client_id: "{{ keycloak_client_id }}"
     secret: "{{ keycloak_client_secret }}"
     description: "{{ keycloak_description }}"
     redirect_uris: "{{ keycloak_redirect_uris }}"
@@ -19,5 +27,3 @@
           access.token.claim: true
           included.custom.audience: "{{ keycloak_client_id }}"
     state: present
-  register: keycloak_client_info
-  changed_when: no


### PR DESCRIPTION
### Description

This removes the changed when 'no' from the keycloak client create
and splits it into two calls. One that creates the initial client
and the second that sets the rest of the definition.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
